### PR TITLE
Phase 6-1: Add multi-stage backend Dockerfile

### DIFF
--- a/examonline/Dockerfile
+++ b/examonline/Dockerfile
@@ -1,0 +1,31 @@
+#Builder Stage
+
+FROM python:3.12-slim AS builder
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    gcc \
+    python3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY pyproject.toml README.md ./ 
+
+RUN pip install --no-cache-dir uv && uv sync --no-install-project
+
+#Runtime
+
+FROM python:3.12-slim
+ 
+WORKDIR /app
+
+RUN pip install --no-cache-dir uv
+
+COPY --from=builder /app /app
+
+COPY . . 
+
+EXPOSE 8000
+
+CMD ["uv", "run", "python", "manage.py", "runserver", "0.0.0.0:8000"]
+


### PR DESCRIPTION
This PR adds a multi-stage Dockerfile for the Django backend
as part of Phase 6-1 (Docker & Docker Compose setup).

- Uses uv for dependency management
- Separates build and runtime stages
- Keeps build tools out of the runtime image

Note:
Backend container expects database services to be running
(via docker-compose.dev.yml). Running the container alone
may fail due to missing PostgreSQL, which is expected.

Refs #17
