### PR TITLE
feat(security): ImageField 파일 업로드 검증 추가

### DIFF
--- a/examonline/apps/testquestion/models.py
+++ b/examonline/apps/testquestion/models.py
@@ -2,6 +2,11 @@ from django.db import models
 from django.utils import timezone
 
 from user.models import UserProfile, SubjectInfo
+from core.api.validators import (
+    validate_image_extension,
+    validate_image_size,
+    validate_image_mime_type,
+)
 
 
 # 시험 문제 정보
@@ -15,7 +20,14 @@ class TestQuestionInfo(models.Model):
     tq_degree = models.CharField(
         choices=(('jd', '쉬움'), ('zd', '보통'), ('kn', '어려움')), max_length=2, verbose_name='시험 난이도', default='jd'
     )
-    image = models.ImageField(upload_to='test_question/%Y/%m', max_length=200, verbose_name='시험 문제 사진', blank=True, null=True)
+    image = models.ImageField(
+        upload_to='test_question/%Y/%m',
+        max_length=200,
+        verbose_name='시험 문제 사진',
+        blank=True,
+        null=True,
+        validators=[validate_image_extension, validate_image_size, validate_image_mime_type],
+    )
     is_del = models.BooleanField(default=False, verbose_name='삭제 여부')
     is_share = models.BooleanField(default=False, verbose_name='공유 여부')
     create_time = models.DateTimeField(default=timezone.now, verbose_name='생성 시간')

--- a/examonline/apps/user/models.py
+++ b/examonline/apps/user/models.py
@@ -2,6 +2,12 @@ from django.db import models
 from django.utils import timezone
 from django.contrib.auth.models import AbstractUser
 
+from core.api.validators import (
+    validate_image_extension,
+    validate_image_size,
+    validate_image_mime_type,
+)
+
 
 # 사용자 기본 정보
 class UserProfile(AbstractUser):
@@ -14,7 +20,13 @@ class UserProfile(AbstractUser):
         choices=(('student', '학생'), ('teacher', '선생')), default='student', max_length=7, verbose_name='사용자 유형'
     )
     age = models.IntegerField(default=18, verbose_name='나이')
-    image = models.ImageField(upload_to='image/%Y/%m', default='image/default.png', max_length=200, verbose_name='이미지')
+    image = models.ImageField(
+        upload_to='image/%Y/%m',
+        default='image/default.png',
+        max_length=200,
+        verbose_name='이미지',
+        validators=[validate_image_extension, validate_image_size, validate_image_mime_type],
+    )
 
     class Meta:
         verbose_name = '사용자 정보'

--- a/examonline/core/api/validators.py
+++ b/examonline/core/api/validators.py
@@ -1,0 +1,102 @@
+"""
+Image file validators for Django models.
+
+Provides validation for:
+- File extension (jpg, jpeg, png, gif)
+- File size (default 5MB limit)
+- MIME type verification via magic numbers
+"""
+
+from django.core.exceptions import ValidationError
+from django.core.validators import FileExtensionValidator
+from django.utils.deconstruct import deconstructible
+from django.utils.translation import gettext_lazy as _
+
+
+ALLOWED_IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif']
+MAX_IMAGE_SIZE_MB = 5
+
+
+@deconstructible
+class ImageSizeValidator:
+    """
+    Validator to check file size does not exceed maximum limit.
+
+    Args:
+        max_size_mb: Maximum file size in megabytes (default: 5MB)
+    """
+    message = _('파일 크기가 %(max_size)s MB를 초과합니다. 현재 크기: %(actual_size).2f MB')
+    code = 'file_too_large'
+
+    def __init__(self, max_size_mb=MAX_IMAGE_SIZE_MB):
+        self.max_size_bytes = max_size_mb * 1024 * 1024
+        self.max_size_mb = max_size_mb
+
+    def __call__(self, value):
+        if value.size > self.max_size_bytes:
+            raise ValidationError(
+                self.message,
+                code=self.code,
+                params={
+                    'max_size': self.max_size_mb,
+                    'actual_size': value.size / (1024 * 1024)
+                }
+            )
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, self.__class__)
+            and self.max_size_bytes == other.max_size_bytes
+        )
+
+
+@deconstructible
+class ImageMimeTypeValidator:
+    """
+    Validator to verify actual file type using magic numbers.
+
+    Checks the file header bytes to ensure the file is a valid image,
+    preventing attacks where malicious files are disguised with image extensions.
+    """
+    message = _('허용되지 않는 이미지 형식입니다. 허용 형식: jpg, jpeg, png, gif')
+    code = 'invalid_image_type'
+
+    # Magic numbers for common image formats
+    MAGIC_NUMBERS = {
+        b'\xff\xd8\xff': 'jpeg',
+        b'\x89PNG\r\n\x1a\n': 'png',
+        b'GIF87a': 'gif',
+        b'GIF89a': 'gif',
+    }
+
+    def __init__(self, allowed_types=None):
+        self.allowed_types = allowed_types or ['jpeg', 'png', 'gif']
+
+    def __call__(self, value):
+        # Read file header
+        value.seek(0)
+        header = value.read(8)
+        value.seek(0)  # Reset file pointer
+
+        detected_type = None
+        for magic, file_type in self.MAGIC_NUMBERS.items():
+            if header.startswith(magic):
+                detected_type = file_type
+                break
+
+        if detected_type is None or detected_type not in self.allowed_types:
+            raise ValidationError(self.message, code=self.code)
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, self.__class__)
+            and set(self.allowed_types) == set(getattr(other, 'allowed_types', []))
+        )
+
+
+# Pre-configured validator instances for convenience
+validate_image_extension = FileExtensionValidator(
+    allowed_extensions=ALLOWED_IMAGE_EXTENSIONS
+)
+validate_image_size = ImageSizeValidator()
+validate_image_mime_type = ImageMimeTypeValidator()


### PR DESCRIPTION
## Summary

- `core/api/validators.py` 신규 생성
  - `ImageSizeValidator`: 파일 크기 제한 (기본 5MB)
  - `ImageMimeTypeValidator`: Magic number 기반 실제 파일 타입 검증
  - `validate_image_extension`: 확장자 검증 (jpg, jpeg, png, gif)
- `UserProfile.image` 필드에 validators 적용
- `TestQuestionInfo.image` 필드에 validators 적용

## 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `examonline/core/api/validators.py` | 신규 생성 |
| `examonline/apps/user/models.py` | validators 추가 |
| `examonline/apps/testquestion/models.py` | validators 추가 |

## Test plan

- [ ] Django check 통과 확인
- [ ] 잘못된 확장자 파일 업로드 시 거부 확인
- [ ] 5MB 초과 파일 업로드 시 거부 확인
- [ ] 정상 이미지 업로드 성공 확인

Closes #35