### PR TITLE
refactor: Serializer 코드 중복 제거 (Mixin 도입)

### DIFF
--- a/examonline/apps/examination/api/serializers.py
+++ b/examonline/apps/examination/api/serializers.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 from rest_framework import serializers
 
 from core.api.fields import XSSSanitizedCharField
+from core.api.mixins import CreatUserSerializerMixin
 from examination.models import ExaminationInfo, ExamPaperInfo, ExamStudentsInfo
 from testpaper.models import TestPaperInfo
 from user.models import StudentsInfo, SubjectInfo
@@ -55,7 +56,7 @@ class ExamPaperWriteSerializer(serializers.Serializer):
     )
 
 
-class ExaminationListSerializer(serializers.ModelSerializer):
+class ExaminationListSerializer(CreatUserSerializerMixin, serializers.ModelSerializer):
     """
     시험 목록용 Serializer (경량).
     """
@@ -98,15 +99,6 @@ class ExaminationListSerializer(serializers.ModelSerializer):
         duration = obj.end_time - obj.start_time
         return int(duration.total_seconds() / 60)
 
-    def get_creat_user(self, obj):
-        """Frontend 호환성을 위한 create_user 정보"""
-        if obj.create_user:
-            return {
-                'id': obj.create_user.id,
-                'nick_name': obj.create_user.nick_name,
-            }
-        return None
-
     def get_testpaper(self, obj):
         """첫 번째 연결된 시험지 정보 (Frontend 호환성)
 
@@ -131,7 +123,7 @@ class ExaminationListSerializer(serializers.ModelSerializer):
         return obj.exam_state != '0'
 
 
-class ExaminationDetailSerializer(serializers.ModelSerializer):
+class ExaminationDetailSerializer(CreatUserSerializerMixin, serializers.ModelSerializer):
     """
     시험 상세 조회용 Serializer.
     시험지 및 응시 학생 정보 포함.
@@ -171,15 +163,6 @@ class ExaminationDetailSerializer(serializers.ModelSerializer):
             'is_public',
             'enrolled_students_count',
         ]
-
-    def get_creat_user(self, obj):
-        """Return create_user as object with id and nick_name"""
-        if obj.create_user:
-            return {
-                'id': obj.create_user.id,
-                'nick_name': obj.create_user.nick_name,
-            }
-        return None
 
     def get_testpaper(self, obj):
         """첫 번째 연결된 시험지 정보 (Frontend 호환성)

--- a/examonline/apps/testpaper/api/serializers.py
+++ b/examonline/apps/testpaper/api/serializers.py
@@ -7,6 +7,7 @@ from django.db.models import Sum
 from rest_framework import serializers
 
 from core.api.fields import XSSSanitizedCharField
+from core.api.mixins import CreatUserSerializerMixin, PassedScoreSerializerMixin
 from testpaper.models import TestPaperInfo, TestPaperTestQ
 from testquestion.api.serializers import QuestionListSerializer
 from testquestion.models import TestQuestionInfo
@@ -41,7 +42,7 @@ class PaperQuestionWriteSerializer(serializers.Serializer):
     order = serializers.IntegerField(default=1, min_value=1)
 
 
-class TestPaperListSerializer(serializers.ModelSerializer):
+class TestPaperListSerializer(CreatUserSerializerMixin, serializers.ModelSerializer):
     """
     시험지 목록 조회용 경량 Serializer.
     문제 목록 미포함.
@@ -70,17 +71,8 @@ class TestPaperListSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ['id', 'total_score', 'question_count', 'created_at', 'updated_at', 'creat_user']
 
-    def get_creat_user(self, obj):
-        """Frontend 호환성을 위한 create_user 정보"""
-        if obj.create_user:
-            return {
-                'id': obj.create_user.id,
-                'nick_name': obj.create_user.nick_name,
-            }
-        return None
 
-
-class TestPaperDetailSerializer(serializers.ModelSerializer):
+class TestPaperDetailSerializer(CreatUserSerializerMixin, serializers.ModelSerializer):
     """
     시험지 상세 조회용 Serializer.
     문제 목록 포함.
@@ -118,15 +110,6 @@ class TestPaperDetailSerializer(serializers.ModelSerializer):
             'creat_user',
             'questions',
         ]
-
-    def get_creat_user(self, obj):
-        """Return create_user as object with id and nick_name"""
-        if obj.create_user:
-            return {
-                'id': obj.create_user.id,
-                'nick_name': obj.create_user.nick_name,
-            }
-        return None
 
 
 class TestPaperCreateSerializer(serializers.ModelSerializer):
@@ -299,7 +282,7 @@ class StudentBasicSerializer(serializers.ModelSerializer):
         fields = ['id', 'student_name', 'student_id', 'student_class']
 
 
-class MyScoreListSerializer(serializers.ModelSerializer):
+class MyScoreListSerializer(PassedScoreSerializerMixin, serializers.ModelSerializer):
     """
     학생용 성적 목록 Serializer.
     """
@@ -324,12 +307,6 @@ class MyScoreListSerializer(serializers.ModelSerializer):
             'time_used',
             'passed',
         ]
-
-    def get_passed(self, obj):
-        """합격 여부"""
-        if obj.test_paper and obj.is_submitted:
-            return obj.test_score >= obj.test_paper.passing_score
-        return None
 
 
 class QuestionResultSerializer(serializers.Serializer):
@@ -427,7 +404,7 @@ class MyScoreDetailSerializer(serializers.ModelSerializer):
         return results
 
 
-class ExamScoreListSerializer(serializers.ModelSerializer):
+class ExamScoreListSerializer(PassedScoreSerializerMixin, serializers.ModelSerializer):
     """
     교사용 시험별 성적 목록 Serializer.
     """
@@ -447,12 +424,6 @@ class ExamScoreListSerializer(serializers.ModelSerializer):
             'is_submitted',
             'passed',
         ]
-
-    def get_passed(self, obj):
-        """합격 여부"""
-        if obj.test_paper and obj.is_submitted:
-            return obj.test_score >= obj.test_paper.passing_score
-        return None
 
 
 class ExamStatisticsSerializer(serializers.Serializer):

--- a/examonline/apps/testquestion/api/serializers.py
+++ b/examonline/apps/testquestion/api/serializers.py
@@ -6,6 +6,7 @@ from django.db import transaction
 from rest_framework import serializers
 
 from core.api.fields import XSSSanitizedCharField
+from core.api.mixins import CreatUserSerializerMixin
 from testquestion.models import TestQuestionInfo, OptionInfo
 from user.api.serializers import SubjectSerializer
 from user.models import SubjectInfo
@@ -36,7 +37,7 @@ class OptionWriteSerializer(serializers.ModelSerializer):
         fields = ['id', 'option', 'is_right']
 
 
-class QuestionListSerializer(serializers.ModelSerializer):
+class QuestionListSerializer(CreatUserSerializerMixin, serializers.ModelSerializer):
     """
     문제 목록 조회용 경량 Serializer.
     옵션은 포함하지 않음.
@@ -70,21 +71,12 @@ class QuestionListSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ['id', 'created_at', 'updated_at', 'creat_user', 'is_del', 'options']
 
-    def get_creat_user(self, obj):
-        """Return create_user as object with id and nick_name"""
-        if obj.create_user:
-            return {
-                'id': obj.create_user.id,
-                'nick_name': obj.create_user.nick_name,
-            }
-        return None
-
     def get_options(self, obj):
         """Return empty array for list view (options only in detail view)"""
         return []
 
 
-class QuestionDetailSerializer(serializers.ModelSerializer):
+class QuestionDetailSerializer(CreatUserSerializerMixin, serializers.ModelSerializer):
     """
     문제 상세 조회용 Serializer.
     옵션 목록 포함.
@@ -119,15 +111,6 @@ class QuestionDetailSerializer(serializers.ModelSerializer):
             'options',
         ]
         read_only_fields = ['id', 'created_at', 'updated_at', 'creat_user', 'options', 'is_del']
-
-    def get_creat_user(self, obj):
-        """Return create_user as object with id and nick_name"""
-        if obj.create_user:
-            return {
-                'id': obj.create_user.id,
-                'nick_name': obj.create_user.nick_name,
-            }
-        return None
 
 
 class QuestionCreateSerializer(serializers.ModelSerializer):

--- a/examonline/core/api/mixins.py
+++ b/examonline/core/api/mixins.py
@@ -1,0 +1,54 @@
+"""
+Serializer Mixin classes for common field patterns.
+
+These mixins eliminate code duplication across serializers by providing
+reusable implementations of commonly repeated serializer methods.
+"""
+
+
+class CreatUserSerializerMixin:
+    """
+    Mixin to serialize create_user field as object with id and nick_name.
+
+    Usage:
+        class MySerializer(CreatUserSerializerMixin, serializers.ModelSerializer):
+            creat_user = serializers.SerializerMethodField()
+            ...
+
+    Requirements:
+        - Model must have create_user ForeignKey field
+        - create_user must reference UserProfile model with nick_name field
+    """
+
+    def get_creat_user(self, obj):
+        """Return create_user as object with id and nick_name."""
+        if obj.create_user:
+            return {
+                'id': obj.create_user.id,
+                'nick_name': obj.create_user.nick_name,
+            }
+        return None
+
+
+class PassedScoreSerializerMixin:
+    """
+    Mixin to calculate pass/fail status for test scores.
+
+    Usage:
+        class MySerializer(PassedScoreSerializerMixin, serializers.ModelSerializer):
+            passed = serializers.SerializerMethodField()
+            ...
+
+    Requirements:
+        - Model must have test_paper and test_score fields
+        - test_paper must have passing_score field
+    """
+
+    def get_passed(self, obj):
+        """Return pass/fail status based on test score vs passing score."""
+        if obj.test_paper:
+            # Check is_submitted field if exists
+            if hasattr(obj, 'is_submitted') and not obj.is_submitted:
+                return None
+            return obj.test_score >= obj.test_paper.passing_score
+        return None


### PR DESCRIPTION
## Summary

- `core/api/mixins.py` 신규 생성
  - `CreatUserSerializerMixin`: create_user 필드 직렬화 공통 로직
  - `PassedScoreSerializerMixin`: 합격 여부 계산 공통 로직
- 8개 Serializer 클래스에 Mixin 적용
- 중복 코드 제거: `get_creat_user` 6회, `get_passed` 2회

## 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `examonline/core/api/mixins.py` | 신규 생성 |
| `examonline/apps/testquestion/api/serializers.py` | Mixin 적용 (2개 클래스) |
| `examonline/apps/examination/api/serializers.py` | Mixin 적용 (2개 클래스) |
| `examonline/apps/testpaper/api/serializers.py` | Mixin 적용 (4개 클래스) |

## Test plan

- [ ] Django check 통과 확인
- [ ] 기존 API 응답 형식 변경 없음 확인
- [ ] Serializer 동작 테스트

Closes #36