### PR TITLE
fix(e2e): E2E 테스트 Flaky 문제 해결

### DIFF
--- a/frontend/e2e/helpers/assertions.helper.ts
+++ b/frontend/e2e/helpers/assertions.helper.ts
@@ -43,8 +43,12 @@ export async function waitForLoadingComplete(page: Page) {
     // 로딩 스피너가 없는 경우 무시
   }
 
-  // 네트워크 요청이 완료될 때까지 대기
-  await page.waitForLoadState('networkidle', { timeout: 10000 })
+  // 네트워크 요청이 완료될 때까지 대기 (시험 페이지는 Timer/Heartbeat로 인해 networkidle 불가)
+  try {
+    await page.waitForLoadState('networkidle', { timeout: 5000 })
+  } catch {
+    await page.waitForLoadState('domcontentloaded', { timeout: 3000 })
+  }
 }
 
 /**

--- a/frontend/e2e/tests/integration/full-exam-flow.spec.ts
+++ b/frontend/e2e/tests/integration/full-exam-flow.spec.ts
@@ -90,7 +90,8 @@ test.describe('Full Exam Flow Integration Test', () => {
 
       // 시험 응시 페이지로 이동되었는지 확인
       await page.waitForURL(/\/exams\/\d+\/take/)
-      await expect(page.locator('h2')).toContainText(examTitle)
+      await page.waitForSelector('h2', { timeout: 10000 })
+      await expect(page.locator('h2')).toContainText(examTitle, { timeout: 5000 })
       console.log(`✓ Student started exam "${examTitle}"`)
     })
 

--- a/frontend/e2e/tests/student/exam-advanced.spec.ts
+++ b/frontend/e2e/tests/student/exam-advanced.spec.ts
@@ -175,10 +175,11 @@ test.describe('Student Exam Advanced Features', () => {
 
       await waitForLoadingComplete(page)
 
-      // 시험 페이지 로드 확인 - 타이머 표시
+      // 타이머 요소가 보일 때까지 명시적 대기
+      await page.waitForSelector('text=/\\d{2}:\\d{2}:\\d{2}/', { timeout: 15000 })
       await expect(
         page.locator('text=/\\d{2}:\\d{2}:\\d{2}/')
-      ).toBeVisible({ timeout: 15000 })
+      ).toBeVisible({ timeout: 5000 })
 
       console.log('✓ Exam started')
     })


### PR DESCRIPTION
## 개요 (Overview)
E2E 테스트의 간헐적 실패(Flaky) 문제를 해결한다. 시험 페이지의 지속적인 네트워크 요청(Timer, Heartbeat)으로 인한 `networkidle` 타임아웃과 요소 렌더링 대기 문제를 수정했다.

## 주요 변경 사항 (Key Changes)
- `assertions.helper.ts`: `waitForLoadingComplete()` 함수의 `networkidle` 대기를 try-catch로 감싸고, 실패 시 `domcontentloaded`로 fallback
- `full-exam-flow.spec.ts`: h2 요소 assertion 전에 `waitForSelector` 추가
- `exam-advanced.spec.ts`: 타이머 요소 assertion 전에 `waitForSelector` 추가

## 문제 해결 및 테스트 결과 (Problem Solving & Verification)
- **문제 원인**: 시험 응시 페이지는 타이머와 heartbeat로 인해 지속적인 네트워크 요청이 발생하여 `networkidle` 상태에 도달하지 않음
- **해결 방법**: 
  - `networkidle` 대기 시간을 5초로 단축하고 실패 시 `domcontentloaded`로 fallback
  - 요소 assertion 전에 명시적 `waitForSelector` 추가로 요소 렌더링 완료 보장

## 연관 이슈 (Linked Issues)
- Closes #50
- Closes #51 (Duplicate of #50)