### PR TITLE
feat(e2e): E2E 테스트 Mock 시간 시스템 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,7 @@ jobs:
           POSTGRES_USER: examuser
           POSTGRES_PASSWORD: exampass
           DJANGO_SETTINGS_MODULE: config.local
+          E2E_MOCK_TIME_ENABLED: "true"
         run: uv run python manage.py migrate
 
       - name: Create test subjects
@@ -145,6 +146,7 @@ jobs:
           POSTGRES_USER: examuser
           POSTGRES_PASSWORD: exampass
           DJANGO_SETTINGS_MODULE: config.local
+          E2E_MOCK_TIME_ENABLED: "true"
         run: |
           uv run python manage.py shell -c "
           from user.models import SubjectInfo
@@ -161,6 +163,7 @@ jobs:
           POSTGRES_USER: examuser
           POSTGRES_PASSWORD: exampass
           DJANGO_SETTINGS_MODULE: config.local
+          E2E_MOCK_TIME_ENABLED: "true"
         run: |
           uv run python manage.py runserver &
           sleep 10

--- a/examonline/apps/examination/api/serializers.py
+++ b/examonline/apps/examination/api/serializers.py
@@ -12,6 +12,7 @@ from user.models import StudentsInfo, SubjectInfo
 
 from core.api.fields import XSSSanitizedCharField
 from core.api.mixins import CreatUserSerializerMixin
+from core.time import get_now
 
 
 class SubjectSerializer(serializers.ModelSerializer):
@@ -248,7 +249,7 @@ class ExaminationCreateSerializer(serializers.ModelSerializer):
         duration = attrs.get("duration")
 
         # 시작 시간 검증
-        if start_time and start_time < timezone.now():
+        if start_time and start_time < get_now():
             raise serializers.ValidationError(
                 {"start_time": "시작 시간은 현재 시간 이후여야 합니다."}
             )
@@ -317,7 +318,7 @@ class ExaminationUpdateSerializer(serializers.ModelSerializer):
         duration = attrs.get("duration")
 
         # 시작 시간 검증
-        if start_time < timezone.now():
+        if start_time < get_now():
             raise serializers.ValidationError(
                 {"start_time": "시작 시간은 현재 시간 이후여야 합니다."}
             )

--- a/examonline/apps/examination/api/taking_views.py
+++ b/examonline/apps/examination/api/taking_views.py
@@ -16,6 +16,8 @@ from testpaper.models import TestPaperTestQ, TestScores
 from testquestion.models import OptionInfo, TestQuestionInfo
 from user.models import StudentsInfo
 
+from core.time import get_now
+
 from .serializers import (
     AnswerSubmissionSerializer,
     ExamQuestionSerializer,
@@ -58,7 +60,7 @@ class ExamTakingViewSet(viewsets.ViewSet):
             )
 
         # 학생이 등록된 시험 중 아직 제출하지 않은 시험 조회
-        now = timezone.now()
+        now = get_now()
         student_exams = (
             ExamStudentsInfo.objects.filter(student=student_info)
             .select_related("exam")
@@ -225,7 +227,7 @@ class ExamTakingViewSet(viewsets.ViewSet):
             )
 
         # 시험 시간 확인
-        now = timezone.now()
+        now = get_now()
         if now < exam.start_time:
             return Response(
                 {"detail": "아직 시험 시작 시간이 아닙니다."}, status=status.HTTP_400_BAD_REQUEST
@@ -318,7 +320,7 @@ class ExamTakingViewSet(viewsets.ViewSet):
             )
 
         # 제한 시간 확인
-        now = timezone.now()
+        now = get_now()
         is_auto_submitted = False
 
         if now > exam.end_time:
@@ -465,7 +467,7 @@ class ExamTakingViewSet(viewsets.ViewSet):
         else:
             time_remaining = None
             if test_score.start_time and not test_score.is_submitted:
-                now = timezone.now()
+                now = get_now()
                 remaining_seconds = (exam.end_time - now).total_seconds()
                 time_remaining = max(0, int(remaining_seconds / 60))
 
@@ -521,7 +523,7 @@ class ExamTakingViewSet(viewsets.ViewSet):
         test_score.save()
 
         return Response(
-            {"detail": "임시 저장되었습니다.", "saved_at": timezone.now()},
+            {"detail": "임시 저장되었습니다.", "saved_at": get_now()},
             status=status.HTTP_200_OK,
         )
 

--- a/examonline/config/local.py
+++ b/examonline/config/local.py
@@ -10,6 +10,10 @@ from dotenv import load_dotenv
 
 from .base import *
 
+# E2E Mock Time 활성화 (환경 변수로 제어)
+# E2E 테스트에서 시간 동기화 문제 해결을 위해 사용
+E2E_MOCK_TIME_ENABLED = os.getenv("E2E_MOCK_TIME_ENABLED", "false").lower() == "true"
+
 # Load environment variables from .env file
 load_dotenv(BASE_DIR / ".env")
 

--- a/examonline/core/api/e2e_views.py
+++ b/examonline/core/api/e2e_views.py
@@ -1,0 +1,175 @@
+"""
+E2E 테스트 전용 API Endpoint.
+
+E2E_MOCK_TIME_ENABLED 환경에서만 활성화.
+Production 환경에서는 절대 사용되어서는 안 됨.
+"""
+
+from django.conf import settings
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+
+from core.time import advance_mock_time, clear_mock_time, get_now, set_mock_time
+
+
+def _check_e2e_enabled():
+    """E2E Mock Time 기능 활성화 여부 확인."""
+    if not getattr(settings, "E2E_MOCK_TIME_ENABLED", False):
+        return Response(
+            {"detail": "E2E Mock Time API is not available in this environment"},
+            status=status.HTTP_403_FORBIDDEN,
+        )
+    return None
+
+
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def get_current_time(request):
+    """
+    현재 서버 시간 조회 (Mock 또는 실제).
+
+    GET /api/v1/e2e/time/
+
+    Returns:
+        {
+            "current_time": "2024-01-01T12:00:00+09:00",
+            "is_mocked": false
+        }
+    """
+    error_response = _check_e2e_enabled()
+    if error_response:
+        return error_response
+
+    from core.time import is_mock_time_active
+
+    return Response(
+        {
+            "current_time": get_now().isoformat(),
+            "is_mocked": is_mock_time_active(),
+        }
+    )
+
+
+@api_view(["POST"])
+@permission_classes([AllowAny])
+def set_time(request):
+    """
+    Mock 시간 설정.
+
+    POST /api/v1/e2e/time/set/
+
+    Body:
+        {
+            "datetime": "2024-01-01T12:00:00+09:00"  // ISO 8601 형식
+        }
+
+    Returns:
+        {
+            "detail": "Mock time set successfully",
+            "current_time": "2024-01-01T12:00:00+09:00"
+        }
+    """
+    error_response = _check_e2e_enabled()
+    if error_response:
+        return error_response
+
+    datetime_str = request.data.get("datetime")
+    if not datetime_str:
+        return Response(
+            {"detail": "datetime field is required"},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    try:
+        # ISO 8601 형식 파싱
+        dt = timezone.datetime.fromisoformat(datetime_str.replace("Z", "+00:00"))
+
+        # Naive datetime인 경우 timezone-aware로 변환
+        if timezone.is_naive(dt):
+            dt = timezone.make_aware(dt)
+
+        set_mock_time(dt)
+
+        return Response(
+            {
+                "detail": "Mock time set successfully",
+                "current_time": get_now().isoformat(),
+            }
+        )
+    except ValueError as e:
+        return Response(
+            {"detail": f"Invalid datetime format: {e}"},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+
+@api_view(["POST"])
+@permission_classes([AllowAny])
+def advance_time(request):
+    """
+    Mock 시간 전진.
+
+    POST /api/v1/e2e/time/advance/
+
+    Body:
+        {
+            "seconds": 0,
+            "minutes": 0,
+            "hours": 0,
+            "days": 0
+        }
+
+    Returns:
+        {
+            "detail": "Mock time advanced",
+            "current_time": "2024-01-01T12:30:00+09:00"
+        }
+    """
+    error_response = _check_e2e_enabled()
+    if error_response:
+        return error_response
+
+    seconds = request.data.get("seconds", 0)
+    minutes = request.data.get("minutes", 0)
+    hours = request.data.get("hours", 0)
+    days = request.data.get("days", 0)
+
+    new_time = advance_mock_time(seconds=seconds, minutes=minutes, hours=hours, days=days)
+
+    return Response(
+        {
+            "detail": "Mock time advanced",
+            "current_time": new_time.isoformat(),
+        }
+    )
+
+
+@api_view(["POST"])
+@permission_classes([AllowAny])
+def reset_time(request):
+    """
+    Mock 시간 초기화 (실제 시간 사용으로 복귀).
+
+    POST /api/v1/e2e/time/reset/
+
+    Returns:
+        {
+            "detail": "Mock time reset to real time",
+            "current_time": "2024-01-01T12:00:00+09:00"
+        }
+    """
+    error_response = _check_e2e_enabled()
+    if error_response:
+        return error_response
+
+    clear_mock_time()
+
+    return Response(
+        {
+            "detail": "Mock time reset to real time",
+            "current_time": get_now().isoformat(),
+        }
+    )

--- a/examonline/core/api/urls.py
+++ b/examonline/core/api/urls.py
@@ -1,0 +1,21 @@
+"""
+Core API URL Configuration.
+
+E2E 테스트 전용 API Endpoint 포함.
+"""
+
+from django.conf import settings
+from django.urls import path
+
+urlpatterns = []
+
+# E2E Mock Time API는 E2E_MOCK_TIME_ENABLED가 True일 때만 등록
+if getattr(settings, "E2E_MOCK_TIME_ENABLED", False):
+    from core.api.e2e_views import advance_time, get_current_time, reset_time, set_time
+
+    urlpatterns += [
+        path("e2e/time/", get_current_time, name="e2e-time-get"),
+        path("e2e/time/set/", set_time, name="e2e-time-set"),
+        path("e2e/time/advance/", advance_time, name="e2e-time-advance"),
+        path("e2e/time/reset/", reset_time, name="e2e-time-reset"),
+    ]

--- a/examonline/core/time.py
+++ b/examonline/core/time.py
@@ -1,0 +1,103 @@
+"""
+Mock 가능한 시간 유틸리티.
+
+E2E 테스트 환경에서 시간을 제어할 수 있는 기능 제공.
+Production 환경에서는 실제 시간만 사용.
+"""
+
+from datetime import timedelta
+
+from django.conf import settings
+from django.utils import timezone
+
+# Mock 시간 저장소 (Module-level 전역 변수)
+_mock_time = None
+
+
+def get_now():
+    """
+    현재 시간 반환.
+
+    E2E_MOCK_TIME_ENABLED가 True이고 mock 시간이 설정된 경우 mock 시간 반환,
+    그렇지 않으면 실제 시간 반환.
+    """
+    if getattr(settings, "E2E_MOCK_TIME_ENABLED", False) and _mock_time is not None:
+        return _mock_time
+
+    return timezone.now()
+
+
+def set_mock_time(dt):
+    """
+    Mock 시간 설정.
+
+    Args:
+        dt: timezone-aware datetime 객체
+
+    Raises:
+        ValueError: E2E_MOCK_TIME_ENABLED가 False인 경우
+    """
+    global _mock_time
+
+    if not getattr(settings, "E2E_MOCK_TIME_ENABLED", False):
+        raise ValueError("Mock time is only available when E2E_MOCK_TIME_ENABLED=True")
+
+    _mock_time = dt
+
+
+def clear_mock_time():
+    """Mock 시간 초기화 (실제 시간 사용으로 복귀)."""
+    global _mock_time
+    _mock_time = None
+
+
+def advance_mock_time(seconds=0, minutes=0, hours=0, days=0):
+    """
+    Mock 시간 전진.
+
+    현재 mock 시간이 없으면 실제 시간 기준으로 설정 후 전진.
+
+    Args:
+        seconds: 초 단위
+        minutes: 분 단위
+        hours: 시간 단위
+        days: 일 단위
+
+    Returns:
+        새로운 mock 시간
+
+    Raises:
+        ValueError: E2E_MOCK_TIME_ENABLED가 False인 경우
+    """
+    global _mock_time
+
+    if not getattr(settings, "E2E_MOCK_TIME_ENABLED", False):
+        raise ValueError("Mock time is only available when E2E_MOCK_TIME_ENABLED=True")
+
+    base_time = _mock_time if _mock_time is not None else timezone.now()
+    _mock_time = base_time + timedelta(seconds=seconds, minutes=minutes, hours=hours, days=days)
+
+    return _mock_time
+
+
+def is_mock_time_active():
+    """Mock 시간이 활성화되어 있는지 확인."""
+    return getattr(settings, "E2E_MOCK_TIME_ENABLED", False) and _mock_time is not None
+
+
+def get_mock_time_status():
+    """
+    Mock 시간 상태 조회.
+
+    Returns:
+        dict: {
+            'enabled': E2E_MOCK_TIME_ENABLED 설정 값,
+            'is_mocked': mock 시간 사용 중 여부,
+            'current_time': 현재 시간 (mock 또는 실제)
+        }
+    """
+    return {
+        "enabled": getattr(settings, "E2E_MOCK_TIME_ENABLED", False),
+        "is_mocked": is_mock_time_active(),
+        "current_time": get_now(),
+    }

--- a/examonline/examonline/urls.py
+++ b/examonline/examonline/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
     path("api/v1/", include("testquestion.api.urls")),
     path("api/v1/", include("testpaper.api.urls")),
     path("api/v1/", include("examination.api.urls")),
+    path("api/v1/", include("core.api.urls")),
     # path('api/v1/', include('operation.api.urls')),
 ]
 

--- a/frontend/e2e/helpers/time.helper.ts
+++ b/frontend/e2e/helpers/time.helper.ts
@@ -1,0 +1,124 @@
+/**
+ * E2E 테스트 Mock 시간 제어 Helper.
+ *
+ * Backend의 Mock 시간 API를 호출하여 시간을 제어.
+ * E2E_MOCK_TIME_ENABLED=true 환경에서만 동작.
+ */
+
+import { createApiClient } from './api.helper'
+
+interface MockTimeResponse {
+  current_time: string
+  is_mocked?: boolean
+  detail?: string
+}
+
+/**
+ * Backend Mock 시간 설정.
+ *
+ * @param datetime ISO 8601 형식의 시간 문자열
+ * @returns 설정된 현재 시간
+ */
+export async function setMockTime(datetime: string): Promise<MockTimeResponse> {
+  const client = createApiClient()
+  const response = await client.post('/e2e/time/set/', { datetime })
+  return response.data
+}
+
+/**
+ * Backend Mock 시간 전진.
+ *
+ * @param options 전진할 시간 (seconds, minutes, hours, days)
+ * @returns 전진된 현재 시간
+ */
+export async function advanceMockTime(options: {
+  seconds?: number
+  minutes?: number
+  hours?: number
+  days?: number
+}): Promise<MockTimeResponse> {
+  const client = createApiClient()
+  const response = await client.post('/e2e/time/advance/', options)
+  return response.data
+}
+
+/**
+ * Backend Mock 시간 초기화 (실제 시간 사용으로 복귀).
+ */
+export async function resetMockTime(): Promise<MockTimeResponse> {
+  const client = createApiClient()
+  const response = await client.post('/e2e/time/reset/')
+  return response.data
+}
+
+/**
+ * 현재 Backend 시간 조회.
+ *
+ * @returns 현재 시간 및 mock 여부
+ */
+export async function getCurrentServerTime(): Promise<{
+  current_time: string
+  is_mocked: boolean
+}> {
+  const client = createApiClient()
+  const response = await client.get('/e2e/time/')
+  return response.data
+}
+
+/**
+ * 시험 시작 시간으로 Mock 시간 설정.
+ * 시험이 즉시 응시 가능하도록 시작 시간으로 설정.
+ *
+ * @param examStartTime 시험 시작 시간 (ISO 8601)
+ */
+export async function setTimeForExamStart(examStartTime: string): Promise<void> {
+  await setMockTime(examStartTime)
+}
+
+/**
+ * 시험 종료 직전 시간으로 Mock 시간 설정.
+ * 시험 시간 초과 테스트용.
+ *
+ * @param examEndTime 시험 종료 시간 (ISO 8601)
+ * @param secondsBefore 종료 전 몇 초로 설정할지 (기본값: 10초)
+ */
+export async function setTimeBeforeExamEnd(
+  examEndTime: string,
+  secondsBefore: number = 10
+): Promise<void> {
+  const endTime = new Date(examEndTime)
+  endTime.setSeconds(endTime.getSeconds() - secondsBefore)
+  await setMockTime(endTime.toISOString())
+}
+
+/**
+ * 시험 종료 시간 이후로 Mock 시간 설정.
+ * 시험 자동 제출 테스트용.
+ *
+ * @param examEndTime 시험 종료 시간 (ISO 8601)
+ * @param minutesAfter 종료 후 몇 분으로 설정할지 (기본값: 1분)
+ */
+export async function setTimeAfterExamEnd(
+  examEndTime: string,
+  minutesAfter: number = 1
+): Promise<void> {
+  const endTime = new Date(examEndTime)
+  endTime.setMinutes(endTime.getMinutes() + minutesAfter)
+  await setMockTime(endTime.toISOString())
+}
+
+/**
+ * Mock 시간 API 사용 가능 여부 확인.
+ * E2E_MOCK_TIME_ENABLED가 false인 환경에서는 403 반환.
+ *
+ * @returns Mock 시간 사용 가능 여부
+ */
+export async function isMockTimeAvailable(): Promise<boolean> {
+  try {
+    const client = createApiClient()
+    await client.get('/e2e/time/')
+    return true
+  } catch {
+    return false
+  }
+}

--- a/frontend/e2e/tests/integration/full-exam-flow.spec.ts
+++ b/frontend/e2e/tests/integration/full-exam-flow.spec.ts
@@ -10,6 +10,7 @@ import {
   expectToBeOnDashboard,
   waitForLoadingComplete,
 } from '../../helpers/assertions.helper'
+import { setMockTime, resetMockTime } from '../../helpers/time.helper'
 
 /**
  * 통합 E2E 테스트: Teacher가 시험을 생성하고 Student가 응시하는 전체 플로우 검증
@@ -52,6 +53,12 @@ test.describe('Full Exam Flow Integration Test', () => {
   })
 
   test.afterAll(async () => {
+    // Mock 시간 초기화
+    console.log('=== Resetting mock time ===')
+    await resetMockTime().catch(() => {
+      console.log('Mock time reset skipped (API may not be available)')
+    })
+
     // 테스트 데이터 정리
     console.log('=== Cleaning up test data ===')
 
@@ -62,8 +69,8 @@ test.describe('Full Exam Flow Integration Test', () => {
     })
   })
 
-  // TODO: CI 환경 타이밍 문제로 임시 비활성화 (Issue #54 참조)
-  test.skip('Student가 시험 전체 과정을 완료할 수 있어야 함', async ({ page }) => {
+  // Mock 시간 시스템을 사용하여 CI 환경 타이밍 문제 해결 (Issue #54)
+  test('Student가 시험 전체 과정을 완료할 수 있어야 함', async ({ page }) => {
     const examTitle = examData.examination.name
 
     await test.step('Dashboard에서 시험 확인', async () => {
@@ -80,8 +87,13 @@ test.describe('Full Exam Flow Integration Test', () => {
     })
 
     await test.step('시험 시작', async () => {
-      // 시험 시작 시간 대기 (시험은 +10초 후 시작으로 생성됨)
-      await page.waitForTimeout(12000) // 12초 대기 (10초 + 2초 버퍼)
+      // Mock 시간을 시험 시작 시간으로 설정 (대기 없이 즉시 응시 가능)
+      console.log(`Setting mock time to exam start time: ${examData.examination.start_time}`)
+      await setMockTime(examData.examination.start_time)
+
+      // 페이지 새로고침하여 시간 변경 반영
+      await page.reload()
+      await waitForLoadingComplete(page)
 
       // 시험 카드 찾기 및 시작 버튼 클릭
       const examCard = page.locator(`text=${examTitle}`).locator('..')

--- a/frontend/e2e/tests/student/exam-advanced.spec.ts
+++ b/frontend/e2e/tests/student/exam-advanced.spec.ts
@@ -13,6 +13,7 @@ import {
   apiEnrollStudents,
 } from '../../helpers/api.helper'
 import { loginAsStudent } from '../../helpers/auth.helper'
+import { setMockTime, resetMockTime } from '../../helpers/time.helper'
 
 /**
  * Student 시험 고급 기능 테스트
@@ -29,6 +30,7 @@ test.describe('Student Exam Advanced Features', () => {
   const questionIds: number[] = []
   let testPaperId: number
   let examinationId: number
+  let examStartTime: string
 
   test.beforeAll(async () => {
     // Teacher & Student 계정 생성
@@ -106,12 +108,12 @@ test.describe('Student Exam Advanced Features', () => {
     // 시험 시작 시간 설정 (10초 후)
     // Backend: start_time >= now 검증 통과를 위해 미래 시간 필요
     const now = new Date()
-    const startTime = new Date(now.getTime() + 10 * 1000).toISOString()
+    examStartTime = new Date(now.getTime() + 10 * 1000).toISOString()
 
     const examination = await apiCreateExamination(teacher.tokens.access, {
       name: `고급 기능 테스트 시험 ${Date.now()}`,
       subject_id: subjectId,
-      start_time: startTime,
+      start_time: examStartTime,
       duration: 30, // 30분
       exam_type: 'pt',
       papers: [{ paper_id: testPaperId }],
@@ -129,6 +131,11 @@ test.describe('Student Exam Advanced Features', () => {
   })
 
   test.afterAll(async () => {
+    // Mock 시간 초기화
+    await resetMockTime().catch(() => {
+      console.log('Mock time reset skipped (API may not be available)')
+    })
+
     // 테스트 데이터 정리
     await cleanupTestData(teacher.tokens.access, {
       examinationIds: [examinationId],
@@ -137,8 +144,8 @@ test.describe('Student Exam Advanced Features', () => {
     })
   })
 
-  // TODO: CI 환경 타이밍 문제로 임시 비활성화 (Issue #54 참조)
-  test.skip('Student가 시험 고급 기능을 사용할 수 있어야 함', async ({ page }) => {
+  // Mock 시간 시스템을 사용하여 CI 환경 타이밍 문제 해결 (Issue #54)
+  test('Student가 시험 고급 기능을 사용할 수 있어야 함', async ({ page }) => {
     // 브라우저 콘솔 로그 캡처
     page.on('console', (msg) => {
       if (msg.type() === 'error' || msg.type() === 'warning') {
@@ -157,13 +164,12 @@ test.describe('Student Exam Advanced Features', () => {
     })
 
     await test.step('시험 시작', async () => {
+      // Mock 시간을 시험 시작 시간으로 설정 (대기 없이 즉시 응시 가능)
+      console.log(`Setting mock time to exam start time: ${examStartTime}`)
+      await setMockTime(examStartTime)
+
       // 내 시험 페이지로 이동
       await page.goto('/exams')
-      await waitForLoadingComplete(page)
-
-      // 시험 시작 시간 대기 (시험은 +10초 후 시작으로 생성됨)
-      await page.waitForTimeout(12000) // 12초 대기 (10초 + 2초 버퍼)
-      await page.reload()
       await waitForLoadingComplete(page)
 
       // 시험 응시 버튼 클릭


### PR DESCRIPTION
## 개요 (Overview)

CI 환경에서 Backend와 Test Runner 간의 시간 동기화 문제를 해결하기 위해 Mock 시간 시스템을 구현한다. 시험 생성 시 `start_time >= now` 검증과 시험 시작 시 `now >= start_time` 검증을 동시에 만족시키기 어려운 문제를 해결한다.

## 주요 변경 사항 (Key Changes)

### Backend
- `core/time.py`: Mock 가능한 시간 유틸리티 (`get_now()`, `set_mock_time()`, `advance_mock_time()`, `clear_mock_time()`)
- `core/api/e2e_views.py`: E2E 시간 제어 API Endpoint 4개
  - `GET /api/v1/e2e/time/`: 현재 서버 시간 조회
  - `POST /api/v1/e2e/time/set/`: Mock 시간 설정
  - `POST /api/v1/e2e/time/advance/`: Mock 시간 전진
  - `POST /api/v1/e2e/time/reset/`: 실제 시간으로 초기화
- `config/local.py`: `E2E_MOCK_TIME_ENABLED` 설정 추가
- `taking_views.py`, `serializers.py`: `timezone.now()` -> `get_now()` 교체

### Frontend
- `time.helper.ts`: Backend 시간 제어 Helper 함수
- `full-exam-flow.spec.ts`: `test.skip` 제거, Mock 시간 적용
- `exam-advanced.spec.ts`: `test.skip` 제거, Mock 시간 적용

### CI/CD
- `.github/workflows/ci.yml`: E2E 테스트 환경에 `E2E_MOCK_TIME_ENABLED=true` 추가

## 문제 해결 및 테스트 결과 (Problem Solving & Verification)

### 해결된 문제
- CI 환경에서 Docker Container(Backend)와 Test Runner(Frontend) 간의 미세한 시간 차이로 인한 테스트 실패
- 시험 생성 시 미래 시간 필요, 시험 시작 시 시작 시간 도래 필요 조건 동시 충족 어려움

### 보안 고려사항
- `E2E_MOCK_TIME_ENABLED=true` 환경에서만 Mock 시간 API 활성화
- Production 환경에서는 URL 자체가 등록되지 않음 (조건부 URL 등록)
- `settings.DEBUG`와 무관하게 별도 환경 변수로 제어

### 테스트 검증
- [ ] Backend Unit Test: `core/time.py` 함수 동작 확인
- [ ] E2E 테스트 로컬 실행: `npm run test:e2e`
- [ ] CI Pipeline 통과 확인

## 연관 이슈 (Linked Issues)

Closes #54